### PR TITLE
Fix coverage report

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,6 +1,6 @@
 name: 'coverage'
 on:
-  push:
+  pull_request:
     branches:
       - main
       - beta


### PR DESCRIPTION
The coverage repost suppose to happen once a PR is raised. But it happens after a push is made to the main/beta branch there by not giving us metrics on the quality of the PR.

This PR is a fix for that which forces it to generate coverage on every PR.